### PR TITLE
Fix explorer theme

### DIFF
--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -14480,9 +14480,11 @@ begin
   end;
 
   {$ifdef ThemeSupport}
-  //  if Theme <> 0 then
-  //    CloseThemeData(Theme);
+  {$ifdef Windows}
+    if Theme <> 0 then
+      CloseThemeData(Theme);
   {$endif}
+  {$endif ThemeSupport}
 end;
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -24798,7 +24800,7 @@ begin
             if not IsRectEmpty(InnerRect) then
               {$ifdef ThemeSupport}
               {$ifdef Windows}
-                if Theme <> 0 then
+                if tsUseExplorerTheme in FStates then
                 begin
                   // If the node is also hot, its background will be drawn later.
                   if not (toHotTrack in FOptions.FPaintOptions) or (Node <> FCurrentHotNode) or
@@ -24819,7 +24821,7 @@ begin
 
     {$ifdef ThemeSupport}
     {$ifdef Windows}
-      if (Theme <> 0) and (toHotTrack in FOptions.FPaintOptions) and (Node = FCurrentHotNode) and
+      if (tsUseExplorerTheme in FStates) and (toHotTrack in FOptions.FPaintOptions) and (Node = FCurrentHotNode) and
          ((Column = FCurrentHotColumn) or (toFullRowSelect in FOptions.FSelectionOptions)) then
         DrawBackground(IfThen((vsSelected in Node.States) and not (toAlwaysHideSelection in FOptions.FPaintOptions),
                               TREIS_HOTSELECTED, TREIS_HOT));
@@ -24844,7 +24846,7 @@ begin
         {$ifdef ThemeSupport}
         {$ifdef Windows}
           if not (toExtendedFocus in FOptions.FSelectionOptions) and (toFullRowSelect in FOptions.FSelectionOptions) and
-            (Theme <> 0) then
+            (tsUseExplorerTheme in FStates) then
             FocusRect := RowRect
           else
         {$endif}
@@ -24879,11 +24881,10 @@ begin
     end;
   end;
   {$ifdef ThemeSupport}
-  //todo
-  {
-  if Theme <> 0 then
+  {$ifdef Windows}
+  if tsUseExplorerTheme in FStates then
     CloseThemeData(Theme);
-  }
+  {$endif}
   {$endif ThemeSupport}
 end;
 


### PR DESCRIPTION
Fixed bug when tsUseExplorerTheme disabled (and with default options), the selected node is drawn with no background and white text color. Plus, I merge 2 or 3 changes from LazVTV version.