### PR TITLE
Fix infinite loop in GetPreviousVisibleNoInit(), Laz issue #38836

### DIFF
--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -29444,11 +29444,9 @@ begin
               if Assigned(Result.PrevSibling) then
               begin
                 // No children anymore, so take the previous sibling.
-                if vsVisible in Result.PrevSibling.States then
-                begin
-                  Result := Result.PrevSibling;
+                Result := Result.PrevSibling;
+                if vsVisible in Result.States then
                   Break;
-                end;
               end
               else
               begin


### PR DESCRIPTION
This pull request copies the solution applied to the Laz-VTV upon bug report #38836. Run attached demo (adapted from the bug report), expand the node and see the hang.

Please note that the solution is taken from the JAM Software repo. Therefore, the bug is expected to be present in other branches of the Laz-VTV repo as well - the pull request does not cover these!

[issue38836-demo.zip](https://github.com/blikblum/VirtualTreeView-Lazarus/files/6444222/issue38836-demo.zip)
