### PR TITLE
Fix incremental search when search direction is backwards

### DIFF
--- a/Source/VirtualTrees.pas
+++ b/Source/VirtualTrees.pas
@@ -20768,7 +20768,7 @@ begin
         // VK_BACK temporarily changes search direction to opposite mode.
         if PreviousSearch then
         begin
-          if SearchDirection = sdBackward then
+          if FSearchDirection = sdBackward then
             SearchDirection := sdForward
           else
             SearchDirection := sdBackward


### PR DESCRIPTION
Search direction was compared against uninitialized local variable instead of member variable